### PR TITLE
fix(dashboard-namespace):  Fix a dashboard namespacing issue

### DIFF
--- a/src/services/dashboard/serverless.yml
+++ b/src/services/dashboard/serverless.yml
@@ -55,5 +55,5 @@ resources:
     CloudWatchDashboard:
       Type: AWS::CloudWatch::Dashboard
       Properties:
-        DashboardName: ${sls:stage}-dashboard
+        DashboardName: ${self:service}-${sls:stage}
         DashboardBody: ${file(./templateDashboard.txt)}


### PR DESCRIPTION
## Purpose

This changeset fixes an issue where the CW Dashbaord was not qualified by projcet name... causing resource conlflicts when a second consumer (blackops) dpeloyed this template to the same AWS account.

#### Linked Issues to Close

None

## Approach

Adding a service (including project) qualifier

## Learning

None

## Assorted Notes/Considerations

None
