### PR TITLE
fix(typo): Find instances where cmsgov or old project names are mistakenly hardcoded

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -53,7 +53,7 @@ jobs:
         if: env.SLACK_WEBHOOK != '' && failure()
         env:
           SLACK_COLOR: ${{job.status}}
-          SLACK_ICON: https://github.com/cmsgov.png?size=48
+          SLACK_ICON: https://github.com/${{ github.repository_owner }}.png?size=48
           SLACK_TITLE: Failure
           SLACK_USERNAME: ${{ github.repository }} ${{job.status}}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
@@ -62,8 +62,8 @@ jobs:
         if: env.SLACK_WEBHOOK != ''
         env:
           SLACK_COLOR: ${{job.status}}
-          SLACK_ICON: https://github.com/cmsgov.png?size=48
+          SLACK_ICON: https://github.com/${{ github.repository_owner }}.png?size=48
           SLACK_TITLE: Update Dependencies Workflow - SUCCESS
-          SLACK_MESSAGE: Click https://github.com/cmsgov/cms-bigmac/compare/master...${{ env.deps_branch_name }}?quick_pull=1&labels=deps&title=chore(deps):+Update+Dependencies&body=Update+all+dependencies. to create a PR for the updates to go to master.
+          SLACK_MESSAGE: Click https://github.com/${{ github.repository_owner }}/${{ github.repository }}/compare/master...${{ env.deps_branch_name }}?quick_pull=1&labels=deps&title=chore(deps):+Update+Dependencies&body=Update+all+dependencies. to create a PR for the updates to go to master.
           SLACK_USERNAME: ${{ github.repository }} ${{job.status}}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/running-stage-notifier.yml
+++ b/.github/workflows/running-stage-notifier.yml
@@ -51,7 +51,7 @@ jobs:
         env:
           SLACK_MSG_AUTHOR: ${{ github.repository }}
           SLACK_COLOR: ${{job.status}}
-          SLACK_ICON: https://github.com/cmsgov.png?size=48
+          SLACK_ICON: https://github.com/${{ github.repository_owner }}.png?size=48
           SLACK_TITLE: Currently Running Stages
           SLACK_MESSAGE: ${{ steps.runningStages.outputs.runningStages }}
           SLACK_USERNAME: ${{ github.repository }} - ${{ github.workflow }}
@@ -64,7 +64,7 @@ jobs:
         env:
           SLACK_MSG_AUTHOR: ${{ github.repository }}
           SLACK_COLOR: ${{job.status}}
-          SLACK_ICON: https://github.com/cmsgov.png?size=48
+          SLACK_ICON: https://github.com/${{ github.repository_owner }}.png?size=48
           SLACK_TITLE: Failure retrieving currently running stages
           SLACK_MESSAGE: Failure retrieving currently running stages
           SLACK_USERNAME: ${{ github.repository }} - ${{ github.workflow }}


### PR DESCRIPTION
## Purpose

I found a few instsances in our workflows where 'cmsgov' or 'cms-bigmac' were mistakenly entered.  This moves to get the correct values from the github context.

#### Linked Issues to Close

None

