### PR TITLE
Make OIDC more restricted by changing claim filters

### DIFF
--- a/src/services/.oidc/serverless.yml
+++ b/src/services/.oidc/serverless.yml
@@ -16,6 +16,14 @@ provider:
     PROJECT: ${self:custom.project}
     SERVICE: ${self:service}
 
+params:
+  production:
+    claimFilter: production
+  val:
+    claimFilter: val
+  default:
+    claimFilter: "*"
+
 custom:
   project: ${env:PROJECT}
   serverlessTerminationProtection:
@@ -28,7 +36,7 @@ custom:
     - arn:aws:iam::${aws:accountId}:policy/ADO-Restriction-Policy
     - arn:aws:iam::${aws:accountId}:policy/CMSApprovedAWSServices
     - arn:aws:iam::aws:policy/AdministratorAccess
-  SubjectClaimFilters: "repo:Enterprise-CMCS/macpro-base-template:*"
+  SubjectClaimFilters: "repo:Enterprise-CMCS/macpro-base-template:${params:claimFilter}"
 resources:
   Resources:
     GitHubActionsServiceRole:

--- a/src/services/.oidc/serverless.yml
+++ b/src/services/.oidc/serverless.yml
@@ -36,7 +36,7 @@ custom:
     - arn:aws:iam::${aws:accountId}:policy/ADO-Restriction-Policy
     - arn:aws:iam::${aws:accountId}:policy/CMSApprovedAWSServices
     - arn:aws:iam::aws:policy/AdministratorAccess
-  SubjectClaimFilters: "repo:Enterprise-CMCS/macpro-base-template:${params:claimFilter}"
+  SubjectClaimFilters: "repo:Enterprise-CMCS/macpro-base-template:${param:claimFilter}"
 resources:
   Resources:
     GitHubActionsServiceRole:


### PR DESCRIPTION
This will parameterize the subjectClaimFilters in the .oidc service making it more restrictive when it comes to accessing AWS from github actions.