### PR TITLE
fix(oidc-subjectclaimfilter):  Fix a typo in the OIDC service subjectnamefilter

### DIFF
--- a/src/services/.oidc/serverless.yml
+++ b/src/services/.oidc/serverless.yml
@@ -18,9 +18,9 @@ provider:
 
 params:
   production:
-    claimFilter: production
+    claimFilter: environment:production
   val:
-    claimFilter: val
+    claimFilter: environment:val
   default:
     claimFilter: "*"
 


### PR DESCRIPTION
## Purpose

This fixes a typo in the oidc service.

#### Linked Issues to Close

None

## Approach

This fixes a bug where we were incorrectly setting the OIDC subject name filter for the oidc service role.  We were missing the 'environment' keyword.

## Learning

None

## Assorted Notes/Considerations

None