### PR TITLE
chore(docs):  Add a video walkthrough of new project creation

### DIFF
--- a/docs/docs/z-new-project-creation.md
+++ b/docs/docs/z-new-project-creation.md
@@ -21,15 +21,17 @@ This SOP is suited for anyone involved with project creation. Parts will be non 
 
 ## Video Walkthrough
 
-A video walkthrough is provided; it can accompany you as you step through the documentation, if you find it helpful.
+A video walkthrough of this new project creation procedure is provided, to accompany the docs.  It's our longest video walkthrough, so it's cut into 12 minute parts:
 
-Note: this procedure is long, so the video is cut into 12 minute sections.
+[Part 1 - New Project Setup](https://user-images.githubusercontent.com/48921055/215788850-de1fc49a-18c2-419e-af74-da35816a4a03.mp4){:target="_blank"}
 
-<iframe width="420" height="315" src="https://user-images.githubusercontent.com/48921055/215788850-de1fc49a-18c2-419e-af74-da35816a4a03.mp4" frameborder="0" allowfullscreen></iframe>
-<iframe width="420" height="315" src="https://user-images.githubusercontent.com/48921055/215788887-2fae5af6-eb89-40ff-87ba-314a96d06b06.mp4" frameborder="0" allowfullscreen></iframe>
-<iframe width="420" height="315" src="https://user-images.githubusercontent.com/48921055/215788913-b7e2f76a-614a-4139-8a34-cedeb79e5e60.mp4" frameborder="0" allowfullscreen></iframe>
-<iframe width="420" height="315" src="https://user-images.githubusercontent.com/48921055/215788926-4060eef2-c47a-4067-b17f-a138f91db69b.mp4" frameborder="0" allowfullscreen></iframe>
-<iframe width="420" height="315" src="https://user-images.githubusercontent.com/48921055/215788936-71f91418-8fdd-4cc1-901a-b843de355ed7.mp4" frameborder="0" allowfullscreen></iframe>
+[Part 2 - New Project Setup](https://user-images.githubusercontent.com/48921055/215788887-2fae5af6-eb89-40ff-87ba-314a96d06b06.mp4){:target="_blank"}
+
+[Part 3 - New Project Setup](https://user-images.githubusercontent.com/48921055/215788913-b7e2f76a-614a-4139-8a34-cedeb79e5e60.mp4){:target="_blank"}
+
+[Part 4 - New Project Setup](https://user-images.githubusercontent.com/48921055/215788926-4060eef2-c47a-4067-b17f-a138f91db69b.mp4){:target="_blank"}
+
+[Part 5 - New Project Setup](https://user-images.githubusercontent.com/48921055/215788936-71f91418-8fdd-4cc1-901a-b843de355ed7.mp4){:target="_blank"}
 
 ## Details
 


### PR DESCRIPTION
## Purpose

This updates our documentation to include a video walkthrough of the new project creation process.

#### Linked Issues to Close

Closes https://qmacbis.atlassian.net/browse/OY2-22647

## Approach

- The video was recorded as a screen recording (with audio, without camera) in Quicktime.
- The raw recording was edited in iMovie on Mac.  This included redacting the aws access keys, although they were only temporary credentials that expired long before the video was exported.  Also included, some parts of the video that were waiting on a stack deployment were sped up.
- The video was exported into an mp4
- The mp4 was cut into 12 minute sections with 5 second overlap on each end.  This resulted in 5 videos, all less than 100MB.  This is important, as GitHub's maximum video upload size is 100MB.
- The vids were uploaded to a GitHub Discussion, created specifically to hold videos.
- Links to the vids were added to the new project creation page in our jekyll site.  The links are set to open in a new tab.  We can embed the video instead, but it makes a mess of the page layout; plus i think opening in a new tab lets the user have a large video without losing their place in the docs.  Screenshot below:
<img width="989" alt="Screen Shot 2023-01-31 at 12 44 53 PM" src="https://user-images.githubusercontent.com/48921055/215841319-2de4b511-4186-4aa0-8deb-23de4e40210f.png">


## Learning

None.

## Assorted Notes/Considerations

None.