### PR TITLE
fix(rm-bad-cmd):  Remove a command thats not used and shouldnt be in …

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -157,36 +157,6 @@ yargs(process.argv.slice(2))
     }
   )
   .command(
-    "deleteTopics",
-    "Deletes topics from Bigmac which were created by development/ephemeral branches.",
-    {
-      stage: { type: "string", demandOption: true },
-      // verify: { type: "boolean", demandOption: false, default: true },
-    },
-    async (options) => {
-      await install_deps_for_services();
-      await refreshOutputs("master");
-      await runner.run_command_and_output(
-        `Delete Topics`,
-        [
-          "sls",
-          "topics",
-          "invoke",
-          "--stage",
-          "master",
-          "--function",
-          "deleteTopics",
-          "--data",
-          JSON.stringify({
-            project: process.env.PROJECT,
-            stage: options.stage,
-          }),
-        ],
-        "."
-      );
-    }
-  )
-  .command(
     "docs",
     "Starts the Jekyll documentation site in a docker container, available on http://localhost:4000.",
     {


### PR DESCRIPTION
## Purpose

This changeset removes the run script's deleteTopics command; it should not exist in this repository.

#### Linked Issues to Close

None

## Approach

Updated the file.  Nothing is using it, so that's the extent of the approach.

## Assorted Notes/Considerations/Learning

None