### PR TITLE
feat(silence-runner): Added a silenced parameter to runner and used it in base-update

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -198,7 +198,7 @@ yargs(process.argv.slice(2))
   )
   .command(
     "base-update",
-    "this will upgrade your code to the latest version of the base template",
+    "this will update your code to the latest version of the base template",
     {},
     async () => {
       const addRemoteCommand = [
@@ -210,16 +210,20 @@ yargs(process.argv.slice(2))
       ];
 
       await runner.run_command_and_output(
-        "Upgrade from Base | adding remote",
+        "Update from Base | adding remote",
         addRemoteCommand,
         ".",
-        true
+        true,
+        {
+          stderr: true,
+          close: true,
+        }
       );
 
       const fetchBaseCommand = ["git", "fetch", "base"];
 
       await runner.run_command_and_output(
-        "Upgrade from Base | fetching base template",
+        "Update from Base | fetching base template",
         fetchBaseCommand,
         "."
       );
@@ -227,7 +231,7 @@ yargs(process.argv.slice(2))
       const mergeCommand = ["git", "merge", "base/production", "--no-ff"];
 
       await runner.run_command_and_output(
-        "Upgrade from Base | merging code from base template",
+        "Update from Base | merging code from base template",
         mergeCommand,
         ".",
         true

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -83,22 +83,20 @@ export default class LabeledProcessRunner {
     if (!silenced.open)
       process.stdout.write(`${startingPrefix} Running: ${cmd.join(" ")}\n`);
 
-    proc.stdout.on("data", (data) => {
+    const handleOutput = (data: Buffer, prefix: string, silenced: Boolean) => {
       const paddedPrefix = this.formattedPrefix(prefix);
-
-      if (!silenced.stdout)
+      if (!silenced)
         for (let line of data.toString().split("\n")) {
           process.stdout.write(`${paddedPrefix} ${line}\n`);
         }
-    });
+    };
 
-    proc.stderr.on("data", (data) => {
-      const paddedPrefix = this.formattedPrefix(prefix);
-      if (!silenced.stderr)
-        for (let line of data.toString().split("\n")) {
-          process.stdout.write(`${paddedPrefix} ${line}\n`);
-        }
-    });
+    proc.stdout.on("data", (data) =>
+      handleOutput(data, prefix, silenced.stdout!)
+    );
+    proc.stderr.on("data", (data) =>
+      handleOutput(data, prefix, silenced.stderr!)
+    );
 
     return new Promise<void>((resolve, reject) => {
       proc.on("error", (error) => {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -80,7 +80,7 @@ export default class LabeledProcessRunner {
     if (!silenced.open)
       process.stdout.write(`${paddedPrefix} Running: ${cmd.join(" ")}\n`);
 
-    const handleOutput = (data: Buffer, prefix: string, silenced: Boolean) => {
+    const handleOutput = (data: Buffer, prefix: string, silenced: boolean) => {
       const paddedPrefix = this.formattedPrefix(prefix);
       if (!silenced)
         for (let line of data.toString().split("\n")) {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -58,8 +58,18 @@ export default class LabeledProcessRunner {
     prefix: string,
     cmd: string[],
     cwd: string | null,
-    catchAll = false
+    catchAll = false,
+    silenced: {
+      open?: Boolean;
+      stdout?: Boolean;
+      stderr?: Boolean;
+      close?: Boolean;
+    } = {}
   ) {
+    silenced = {
+      ...{ open: false, stdout: false, stderr: false, close: false },
+      ...silenced,
+    };
     const proc_opts: Record<string, any> = {};
 
     if (cwd) {
@@ -70,33 +80,38 @@ export default class LabeledProcessRunner {
 
     const proc = spawn(command, args, proc_opts);
     const startingPrefix = this.formattedPrefix(prefix);
-    process.stdout.write(`${startingPrefix} Running: ${cmd.join(" ")}\n`);
+    if (!silenced.open)
+      process.stdout.write(`${startingPrefix} Running: ${cmd.join(" ")}\n`);
 
     proc.stdout.on("data", (data) => {
       const paddedPrefix = this.formattedPrefix(prefix);
 
-      for (let line of data.toString().split("\n")) {
-        process.stdout.write(`${paddedPrefix} ${line}\n`);
-      }
+      if (!silenced.stdout)
+        for (let line of data.toString().split("\n")) {
+          process.stdout.write(`${paddedPrefix} ${line}\n`);
+        }
     });
 
     proc.stderr.on("data", (data) => {
       const paddedPrefix = this.formattedPrefix(prefix);
-      for (let line of data.toString().split("\n")) {
-        process.stdout.write(`${paddedPrefix} ${line}\n`);
-      }
+      if (!silenced.stderr)
+        for (let line of data.toString().split("\n")) {
+          process.stdout.write(`${paddedPrefix} ${line}\n`);
+        }
     });
 
     return new Promise<void>((resolve, reject) => {
       proc.on("error", (error) => {
         const paddedPrefix = this.formattedPrefix(prefix);
-        process.stdout.write(`${paddedPrefix} A PROCESS ERROR: ${error}\n`);
+        if (!silenced.stderr)
+          process.stdout.write(`${paddedPrefix} A PROCESS ERROR: ${error}\n`);
         reject(error);
       });
 
       proc.on("close", (code) => {
         const paddedPrefix = this.formattedPrefix(prefix);
-        process.stdout.write(`${paddedPrefix} Exit: ${code}\n`);
+        if (!silenced.close)
+          process.stdout.write(`${paddedPrefix} Exit: ${code}\n`);
         // If there's a failure and we haven't asked to catch all...
         if (code != 0 && !catchAll) {
           // This is not my area.

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -60,28 +60,25 @@ export default class LabeledProcessRunner {
     cwd: string | null,
     catchAll = false,
     silenced: {
-      open?: Boolean;
-      stdout?: Boolean;
-      stderr?: Boolean;
-      close?: Boolean;
+      open?: boolean;
+      stdout?: boolean;
+      stderr?: boolean;
+      close?: boolean;
     } = {}
   ) {
     silenced = {
       ...{ open: false, stdout: false, stderr: false, close: false },
       ...silenced,
     };
-    const proc_opts: Record<string, any> = {};
+    const proc_opts = cwd ? { cwd } : {};
 
-    if (cwd) {
-      proc_opts["cwd"] = cwd;
-    }
     const command = cmd[0];
     const args = cmd.slice(1);
 
     const proc = spawn(command, args, proc_opts);
-    const startingPrefix = this.formattedPrefix(prefix);
+    const paddedPrefix = `[${prefix}]`;
     if (!silenced.open)
-      process.stdout.write(`${startingPrefix} Running: ${cmd.join(" ")}\n`);
+      process.stdout.write(`${paddedPrefix} Running: ${cmd.join(" ")}\n`);
 
     const handleOutput = (data: Buffer, prefix: string, silenced: Boolean) => {
       const paddedPrefix = this.formattedPrefix(prefix);
@@ -100,14 +97,12 @@ export default class LabeledProcessRunner {
 
     return new Promise<void>((resolve, reject) => {
       proc.on("error", (error) => {
-        const paddedPrefix = this.formattedPrefix(prefix);
         if (!silenced.stderr)
           process.stdout.write(`${paddedPrefix} A PROCESS ERROR: ${error}\n`);
         reject(error);
       });
 
       proc.on("close", (code) => {
-        const paddedPrefix = this.formattedPrefix(prefix);
         if (!silenced.close)
           process.stdout.write(`${paddedPrefix} Exit: ${code}\n`);
         // If there's a failure and we haven't asked to catch all...


### PR DESCRIPTION
## Purpose

This adds a 'silenced' parameter to the runner.ts script, and makes use of it in the base-update command.

#### Linked Issues to Close

None

## Approach

The runner.ts script which backs all command issued from run.ts was updated to accept types of output to silence; stdout, stderr etc.  This allows a developer to keep from cluterring a dev's terminal when a command is being run that should be allowed to fail.  

This option was then put into use to silence the `git remote add base xxxxxx` command; this command is not tolerant of an already existing base remote, but we don't care if it fails.  And while we were catching the failure, the error was ugly.  Silence.

## Assorted Notes/Considerations/Learning

None