### PR TITLE
fix(node18 for lambdas):  Update node runtime for lambdas to match nvmrc

### DIFF
--- a/src/services/alerts/serverless.yml
+++ b/src/services/alerts/serverless.yml
@@ -11,7 +11,7 @@ plugins:
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
   region: ${env:REGION_A}
   stackTags:
     PROJECT: ${self:custom.project}

--- a/src/services/dashboard/serverless.yml
+++ b/src/services/dashboard/serverless.yml
@@ -13,7 +13,7 @@ plugins:
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
   region: ${env:REGION_A}
   stackTags:
     PROJECT: ${self:custom.project}


### PR DESCRIPTION
## Purpose

This changeset moves the node runtime for our lambdas from 16 to 18.  I put it as a fix since we upped the runner to 18 awhile back, and probably intended to change this too.

#### Linked Issues to Close

Closes https://qmacbis.atlassian.net/browse/OY2-23056

## Approach

Change node runtime in serverless.yml files.

## Assorted Notes/Considerations/Learning

None