### PR TITLE
fix(dep-update triggers):  remove the dependency update cron trigger

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -2,8 +2,6 @@ name: Dependency Update
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * MON"
 
 concurrency:
   group: ${{ github.workflow }}


### PR DESCRIPTION
## Purpose

This changeset removes the scheduled weekly run of the dependency update workflow.  We decided it was enough to leave it as a manual workflow dispatch only, and avoid the cost and noise of a weekly branch.  There's a fair chance we reverse this decision, I think.

#### Linked Issues to Close

Closes https://qmacbis.atlassian.net/browse/OY2-23012

## Approach

Remove the scheduled trigger.

## Assorted Notes/Considerations/Learning

None