### PR TITLE
feat(add-ac-to-jira-tickets): Add acceptance criteria field to the Jira tickets being automatically created

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -265,6 +265,8 @@ yargs(process.argv.slice(2))
         customJiraFields: {
           customfield_14117: [{ value: "Platform Team" }],
           customfield_14151: [{ value: "Not Applicable " }],
+          customfield_14068:
+            "* All findings of this type are resolved or suppressed, indicated by a Workflow Status of Resolved or Suppressed.  (Note:  this ticket will automatically close when the AC is met.)",
         },
       }).sync();
     }


### PR DESCRIPTION
## Purpose

qmacbis jira has a custom field named acceptance criteria.  This PR is to add the acceptance criteria that we want to the security hub tickets being automatically created.

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-23213?focusedCommentId=118201

## Approach

In our run.ts file, added the acceptance criteria we want to that custom field, just like we're adding the working team is Platform Team
