### PR TITLE
fix(jira commenter):  Adjust message and fix issue with arrow characters.

### DIFF
--- a/.github/workflows/auto-create-jira-comment.yml
+++ b/.github/workflows/auto-create-jira-comment.yml
@@ -15,12 +15,10 @@ jobs:
         env:
           JIRA_BASE_URL: https://qmacbis.atlassian.net/browse/
           JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
+          BODY: ${{ github.event.pull_request.body }}
         if: env.JIRA_TOKEN != ''
         run: |
-          body="${{ github.event.pull_request.body }}"
-          echo "THROUGH"
-          escaped="${body//</ }" 
-          printenv body > .tmp.body.txt
+          printenv BODY > .tmp.body.txt
           issues=(`grep -oP "(?<=${JIRA_BASE_URL})[A-Z]+\d+-\d+" .tmp.body.txt || true`)
           issueJson=`jq -c -n '$ARGS.positional' --args "${issues[@]}"`
           echo "issues=$issueJson" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Purpose

This slightly adjusts the comment put on Jira issues to be more aligned to GitHub.com's behavior, and fixes an issue with special characters in the PR body.

#### Linked Issues to Close

None

## Approach

This was originally just to update the text put on the Jira issue, but I wound up breaking the commenter by having arrow characters in my PR.  I fixed that by setting the pr body as a step env variable, avoiding bash expansion, and using printenv to put the contents into a file.

## Assorted Notes/Considerations/Learning

As a test I'm going to link https://qmacbis.atlassian.net/browse/OY2-23461