### PR TITLE
fix(code-climate): add test coverage percentage

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -28,4 +28,4 @@ jobs:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         with:
           coverageLocations: |
-            ${{github.workspace}}/coverage/lcov.info:lcov
+            ${{github.workspace}}/*.lcov:lcov

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - code-climate
   pull_request:
     branches:
       - master

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,7 +22,7 @@ jobs:
       - run: yarn run coverage
       - name: publish test coverage to code climate
         if: always() && env.CC_TEST_REPORTER_ID != ''
-        uses: paambaati/codeclimate-action@v2.7.1
+        uses: paambaati/codeclimate-action@v3.2.0
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -28,4 +28,4 @@ jobs:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         with:
           coverageLocations: |
-            ${{github.workspace}}/*.lcov:lcov
+            ${{github.workspace}}/coverage/clover.xml:clover

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - code-climate
   pull_request:
     branches:
       - master

--- a/src/services/dashboard/handlers/createDashboardTemplateWidget.ts
+++ b/src/services/dashboard/handlers/createDashboardTemplateWidget.ts
@@ -9,8 +9,12 @@ export const handler = async (
   _context: Context,
   _callback: APIGatewayProxyCallback
 ) => {
-  const lambdaArnToCall = process.env.lambdaArnToCall!;
+  const lambdaArnToCall = process.env.lambdaArnToCall;
   try {
+    if (!lambdaArnToCall) {
+      throw new Error("An error occured");
+    }
+
     const html = `
       <div style="width: 100%; display: flex; justify-content: center;">
         <a class="btn btn-primary">Get Dashboard Template</a>

--- a/src/services/dashboard/tests/createDashboardTemplateWidget.test.ts
+++ b/src/services/dashboard/tests/createDashboardTemplateWidget.test.ts
@@ -7,11 +7,9 @@ import type {
 } from "aws-lambda";
 
 describe("templatize cloudwatch dashboard", () => {
-  beforeEach(() => {
-    process.env.lambdaArnToCall = "test-arn";
-  });
-
   it("should return successful create dashboard template widget", async () => {
+    process.env.lambdaArnToCall = "test-arn";
+
     const html = `
       <div style="width: 100%; display: flex; justify-content: center;">
         <a class="btn btn-primary">Get Dashboard Template</a>
@@ -31,6 +29,8 @@ describe("templatize cloudwatch dashboard", () => {
   });
 
   it("should return unsuccessful create dashboard template widget", async () => {
+    process.env.lambdaArnToCall = "test-arn2";
+
     const html = `
       <div style="width: 100%; display: flex; justify-content: center;">
         <a class="btn btn-primary">Get Dashboard Template</a>
@@ -47,5 +47,21 @@ describe("templatize cloudwatch dashboard", () => {
     );
 
     expect(result).not.toEqual(html);
+  });
+
+  it("should return an error message when there is an error", async () => {
+    process.env = {};
+
+    const result = await handler(
+      {} as APIGatewayEvent,
+      {} as Context,
+      {} as APIGatewayProxyCallback
+    );
+    expect(result).toEqual({
+      statusCode: 200,
+      body: JSON.stringify({
+        message: "An error occured",
+      }),
+    });
   });
 });

--- a/src/services/dashboard/tests/createDashboardTemplateWidget.test.ts
+++ b/src/services/dashboard/tests/createDashboardTemplateWidget.test.ts
@@ -49,7 +49,7 @@ describe("templatize cloudwatch dashboard", () => {
     expect(result).not.toEqual(html);
   });
 
-  it("should return an error message when there is an error", async () => {
+  it("should return an error message when there is an error with the lambda arn", async () => {
     process.env = {};
 
     const result = await handler(

--- a/src/tests/vitest.config.ts
+++ b/src/tests/vitest.config.ts
@@ -1,9 +1,5 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  test: {
-    coverage: {
-      reporter: ["lcov"],
-    },
-  },
+  test: {},
 });

--- a/src/tests/vitest.config.ts
+++ b/src/tests/vitest.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  test: {},
+  test: {
+    coverage: {
+      reporter: ["lcov"],
+    },
+  },
 });


### PR DESCRIPTION
## Purpose
Needed to make changes to the code climate coverage file to be able to correctly read its stats in the github repo. 

#### Linked Issues to Close
https://qmacbis.atlassian.net/browse/OY2-23104

## Approach
An error check was added to createDashboardTemplateWidget. The catch statement would not run without it.

## Assorted Notes/Considerations/Learning
Vitest by default uses clover for their reports
