### PR TITLE
feat(no-squah-for-base-template): Help's devs not to squash for base update

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -218,7 +218,7 @@ yargs(process.argv.slice(2))
         "base",
         "https://github.com/Enterprise-CMCS/macpro-base-template",
       ];
-  
+
       await runner.run_command_and_output(
         "Update from Base | adding remote",
         addRemoteCommand,
@@ -229,20 +229,26 @@ yargs(process.argv.slice(2))
           close: true,
         }
       );
-  
+
       const fetchBaseCommand = ["git", "fetch", "base"];
-  
+
       await runner.run_command_and_output(
         "Update from Base | fetching base template",
         fetchBaseCommand,
         "."
       );
-  
-      const mergeCommand = ["git", "merge", "base/production", "--no-ff", "--no-commit"];
-  
+
+      const mergeCommand = [
+        "git",
+        "merge",
+        "base/production",
+        "--no-ff",
+        "--no-commit",
+      ];
+
       if (mergeCommand.includes("--no-commit")) {
-        const FONT_COLOR_RED = "\x1b[31m";  // Red color
-        const RESET_FORMATTING = "\x1b[0m";  // Reset formatting
+        const FONT_COLOR_RED = "\x1b[31m"; // Red color
+        const RESET_FORMATTING = "\x1b[0m"; // Reset formatting
         const warningMessage = `
         ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
         ╔═══╗╔═══╗╔╗ ╔╗╔════╗╔══╗╔═══╗╔═╗ ╔╗
@@ -256,14 +262,14 @@ yargs(process.argv.slice(2))
   `;
         console.log(warningMessage);
       }
-  
+
       await runner.run_command_and_output(
         "Update from Base | merging code from base template",
         mergeCommand,
         ".",
         true
       );
-  
+
       console.log(
         "Merge command was performed. You may have conflicts. This is normal behavior. To complete the update process, fix any conflicts, commit, push, and open a PR."
       );

--- a/src/run.ts
+++ b/src/run.ts
@@ -208,7 +208,7 @@ yargs(process.argv.slice(2))
   )
   .command(
     "base-update",
-    "This will update your code to the latest version of the base template",
+    "this will update your code to the latest version of the base template",
     {},
     async () => {
       const addRemoteCommand = [

--- a/src/run.ts
+++ b/src/run.ts
@@ -208,7 +208,7 @@ yargs(process.argv.slice(2))
   )
   .command(
     "base-update",
-    "this will update your code to the latest version of the base template",
+    "This will update your code to the latest version of the base template",
     {},
     async () => {
       const addRemoteCommand = [
@@ -218,7 +218,7 @@ yargs(process.argv.slice(2))
         "base",
         "https://github.com/Enterprise-CMCS/macpro-base-template",
       ];
-
+  
       await runner.run_command_and_output(
         "Update from Base | adding remote",
         addRemoteCommand,
@@ -229,26 +229,43 @@ yargs(process.argv.slice(2))
           close: true,
         }
       );
-
+  
       const fetchBaseCommand = ["git", "fetch", "base"];
-
+  
       await runner.run_command_and_output(
         "Update from Base | fetching base template",
         fetchBaseCommand,
         "."
       );
-
+  
       const mergeCommand = ["git", "merge", "base/production", "--no-ff", "--no-commit"];
-
+  
+      if (mergeCommand.includes("--no-commit")) {
+        const FONT_COLOR_RED = "\x1b[31m";  // Red color
+        const RESET_FORMATTING = "\x1b[0m";  // Reset formatting
+        const warningMessage = `
+        ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+        ╔═══╗╔═══╗╔╗ ╔╗╔════╗╔══╗╔═══╗╔═╗ ╔╗
+        ║╔═╗║║╔═╗║║║ ║║║╔╗╔╗║╚╣╠╝║╔═╗║║║╚╗║║
+        ║║ ╚╝║║ ║║║║ ║║╚╝║║╚╝ ║║ ║║ ║║║╔╗╚╝║
+        ║║ ╔╗║╚═╝║║║ ║║  ║║   ║║ ║║ ║║║║╚╗║║
+        ║╚═╝║║╔═╗║║╚═╝║ ╔╝╚╗ ╔╣╠╗║╚═╝║║║ ║║║
+        ╚═══╝╚╝ ╚╝╚═══╝ ╚══╝ ╚══╝╚═══╝╚╝ ╚═╝   
+  
+  ${FONT_COLOR_RED}Attention!!!: You are performing a merge. Be sure to create a merge commit; do NOT squash.${RESET_FORMATTING}
+  `;
+        console.log(warningMessage);
+      }
+  
       await runner.run_command_and_output(
         "Update from Base | merging code from base template",
         mergeCommand,
         ".",
         true
       );
-
+  
       console.log(
-        "Merge command was performed. You may have conflicts. This is normal behaivor. To complete the update process fix any conflicts, commit, push, and open a PR."
+        "Merge command was performed. You may have conflicts. This is normal behavior. To complete the update process, fix any conflicts, commit, push, and open a PR."
       );
     }
   )

--- a/src/run.ts
+++ b/src/run.ts
@@ -238,7 +238,7 @@ yargs(process.argv.slice(2))
         "."
       );
 
-      const mergeCommand = ["git", "merge", "base/production", "--no-ff"];
+      const mergeCommand = ["git", "merge", "base/production", "--no-ff", "--no-commit"];
 
       await runner.run_command_and_output(
         "Update from Base | merging code from base template",


### PR DESCRIPTION
## Purpose

When there are no conflicts, the base-udpate command will commit automatically.  We want to change this behaviour and have the developer perform a manual commit after reviewing the code. This PR adds a --no-commit flag to the merge command and out put a caution banner to alert developers to perform a manual commit.

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-23541

## Approach

This PR adds a --no-commit flag to the merge command and out put a caution banner to alert developers to perform a manual commit.


## Assorted Notes/Considerations/Learning


