### PR TITLE
feat(Parameterize-Org-name): Abstract and Parameterize Org name in deploy-metrics

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -4,7 +4,7 @@ name: GitHub Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["ishmetrics-2"]
+    branches: ["master"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -4,7 +4,7 @@ name: GitHub Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["master"]
+    branches: ["ishmetrics-2"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/docs/_deploy-metrics/lib/getAwsResources.ts
+++ b/docs/_deploy-metrics/lib/getAwsResources.ts
@@ -48,8 +48,8 @@ export const getAwsResources = async (branch: string) => {
   const response = await octokit.request(
     `GET /repos/{owner}/{repo}/actions/artifacts/${artifacts[0].id}/zip`,
     {
-      owner: "Enterprise-CMCS",
-      repo: getRepoName,
+      owner,
+      repo,
     }
   );
 

--- a/docs/_deploy-metrics/lib/getAwsResources.ts
+++ b/docs/_deploy-metrics/lib/getAwsResources.ts
@@ -1,5 +1,5 @@
 import { octokit } from "./octokit";
-import { getRepoName } from "./getRepoName";
+//import { getRepoName } from "./getRepoName";
 import JSZip from 'jszip';
 
 export interface Resource   {
@@ -18,13 +18,15 @@ const unzip = async (blob: string) => {
 }
 
 export const getAwsResources = async (branch: string) => {
+  const repoInfo = process.env.GITHUB_REPOSITORY || "";
+  const [owner, repo] = repoInfo.split("/");
 
   // get a list of the artifacts created by the deploy step
   const artifacts = await octokit.paginate(
     "GET /repos/{owner}/{repo}/actions/artifacts",
     {
-      owner: "Enterprise-CMCS",
-      repo: getRepoName,
+      owner,
+      repo,
       per_page: 100,
       name: 'aws-resources-' + branch
     },

--- a/docs/_deploy-metrics/lib/getAwsResources.ts
+++ b/docs/_deploy-metrics/lib/getAwsResources.ts
@@ -17,7 +17,7 @@ const unzip = async (blob: string) => {
 }
 
 export const getAwsResources = async (branch: string) => {
-  const repoInfo = process.env.GITHUB_REPOSITORY || "";
+  const repoInfo = process.env.GITHUB_REPOSITORY || "orgNotSpecified/repoNotSpecified";
   const [owner, repo] = repoInfo.split("/");
 
   // get a list of the artifacts created by the deploy step

--- a/docs/_deploy-metrics/lib/getAwsResources.ts
+++ b/docs/_deploy-metrics/lib/getAwsResources.ts
@@ -1,5 +1,4 @@
 import { octokit } from "./octokit";
-//import { getRepoName } from "./getRepoName";
 import JSZip from 'jszip';
 
 export interface Resource   {

--- a/docs/_deploy-metrics/lib/getMeanTimeToRecover.ts
+++ b/docs/_deploy-metrics/lib/getMeanTimeToRecover.ts
@@ -1,6 +1,5 @@
 import { octokit } from "./octokit";
 import differenceInHours from "date-fns/differenceInHours";
-//import { getRepoName } from "./getRepoName";
 
 export const getMeanTimeToRecover = async (branch: string) => {
   const repoInfo = process.env.GITHUB_REPOSITORY || "";

--- a/docs/_deploy-metrics/lib/getMeanTimeToRecover.ts
+++ b/docs/_deploy-metrics/lib/getMeanTimeToRecover.ts
@@ -1,19 +1,24 @@
 import { octokit } from "./octokit";
 import differenceInHours from "date-fns/differenceInHours";
-import { getRepoName } from "./getRepoName";
+//import { getRepoName } from "./getRepoName";
 
 export const getMeanTimeToRecover = async (branch: string) => {
+  const repoInfo = process.env.GITHUB_REPOSITORY || "";
+  console.log(repoInfo)
+  const [owner, repo] = repoInfo.split("/");
+
   const response = await octokit.paginate(
     "GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs",
     {
-      owner: "Enterprise-CMCS",
-      repo: getRepoName,
+      owner,
+      repo,
       workflow_id: "deploy.yml",
       branch,
       per_page: 100,
     },
     (response) => response.data.flat()
   );
+
 
   const getTimes = (jobs: typeof response) => {
     const result = [];

--- a/docs/_deploy-metrics/lib/getMeanTimeToRecover.ts
+++ b/docs/_deploy-metrics/lib/getMeanTimeToRecover.ts
@@ -2,7 +2,7 @@ import { octokit } from "./octokit";
 import differenceInHours from "date-fns/differenceInHours";
 
 export const getMeanTimeToRecover = async (branch: string) => {
-  const repoInfo = process.env.GITHUB_REPOSITORY || "";
+  const repoInfo = process.env.GITHUB_REPOSITORY || "orgNotSpecified/repoNotSpecified";
   console.log(repoInfo)
   const [owner, repo] = repoInfo.split("/");
 

--- a/docs/_deploy-metrics/lib/getPrsToBranch.ts
+++ b/docs/_deploy-metrics/lib/getPrsToBranch.ts
@@ -2,7 +2,7 @@ import { octokit } from "./octokit";
 import differenceInHours from "date-fns/differenceInHours";
 
 export const getPrsToBranch = async (branch: string) => {
-  const repoInfo = process.env.GITHUB_REPOSITORY || "";
+  const repoInfo = process.env.GITHUB_REPOSITORY || "orgNotSpecified/repoNotSpecified";
   const [owner, repo] = repoInfo.split("/");
 
   const data = await octokit.paginate(

--- a/docs/_deploy-metrics/lib/getPrsToBranch.ts
+++ b/docs/_deploy-metrics/lib/getPrsToBranch.ts
@@ -1,11 +1,10 @@
 import { octokit } from "./octokit";
 import differenceInHours from "date-fns/differenceInHours";
-//import { getRepoName } from "./getRepoName";
 
 export const getPrsToBranch = async (branch: string) => {
   const repoInfo = process.env.GITHUB_REPOSITORY || "";
   const [owner, repo] = repoInfo.split("/");
-  
+
   const data = await octokit.paginate(
     "GET /repos/{owner}/{repo}/pulls",
     {

--- a/docs/_deploy-metrics/lib/getPrsToBranch.ts
+++ b/docs/_deploy-metrics/lib/getPrsToBranch.ts
@@ -1,13 +1,16 @@
 import { octokit } from "./octokit";
 import differenceInHours from "date-fns/differenceInHours";
-import { getRepoName } from "./getRepoName";
+//import { getRepoName } from "./getRepoName";
 
 export const getPrsToBranch = async (branch: string) => {
+  const repoInfo = process.env.GITHUB_REPOSITORY || "";
+  const [owner, repo] = repoInfo.split("/");
+  
   const data = await octokit.paginate(
     "GET /repos/{owner}/{repo}/pulls",
     {
-      owner: "Enterprise-CMCS",
-      repo: getRepoName,
+      owner,
+      repo,
       state: "closed",
       per_page: 100,
       base: branch,

--- a/docs/_deploy-metrics/lib/getRepoName.ts
+++ b/docs/_deploy-metrics/lib/getRepoName.ts
@@ -1,3 +1,0 @@
-import packageJson from "../../../package.json";
-
-export const getRepoName = packageJson.name;

--- a/docs/_deploy-metrics/lib/getSuccessfulDeploys.ts
+++ b/docs/_deploy-metrics/lib/getSuccessfulDeploys.ts
@@ -1,4 +1,3 @@
-//import { getRepoName } from "./getRepoName";
 import { octokit } from "./octokit";
 
 export const getSuccessfulDeploys = async (branch: string) => {

--- a/docs/_deploy-metrics/lib/getSuccessfulDeploys.ts
+++ b/docs/_deploy-metrics/lib/getSuccessfulDeploys.ts
@@ -1,12 +1,15 @@
-import { getRepoName } from "./getRepoName";
+//import { getRepoName } from "./getRepoName";
 import { octokit } from "./octokit";
 
 export const getSuccessfulDeploys = async (branch: string) => {
+  const repoInfo = process.env.GITHUB_REPOSITORY || "";
+  const [owner, repo] = repoInfo.split("/");
+
   const data = await octokit.paginate(
     "GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs",
     {
-      owner: "Enterprise-CMCS",
-      repo: getRepoName,
+      owner,
+      repo,
       workflow_id: "deploy.yml",
       branch,
       per_page: 100,

--- a/docs/_deploy-metrics/lib/getSuccessfulDeploys.ts
+++ b/docs/_deploy-metrics/lib/getSuccessfulDeploys.ts
@@ -1,7 +1,7 @@
 import { octokit } from "./octokit";
 
 export const getSuccessfulDeploys = async (branch: string) => {
-  const repoInfo = process.env.GITHUB_REPOSITORY || "";
+  const repoInfo = process.env.GITHUB_REPOSITORY || "orgNotSpecified/repoNotSpecified";
   const [owner, repo] = repoInfo.split("/");
 
   const data = await octokit.paginate(


### PR DESCRIPTION
## Purpose

There are a few places in deploy-metrics where ‘Enterprise-CMCS’ is hardcoded. We need to pass in the repo org as a variable.This PR abstract all instances of ‘enterprise-cmcs’ into a single variable, passed in by the github action.

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-23207

## Approach
The process.env.GITHUB_REPOSITORY variable is used to retrieve the repository information. It is then split into owner and repo variables. These variables are then passed to the GitHub API call in the owner and repo fields respectively.

